### PR TITLE
Add slider to fine-tune bar opacity

### DIFF
--- a/desktop/bar/barwindow.cpp
+++ b/desktop/bar/barwindow.cpp
@@ -53,6 +53,9 @@ struct BarWindowPrivate {
     bool statusCenterShown = false;
 
     tSettings settings;
+
+    bool translucencyEnabled = true;
+    int translucencyOpacity = 150;
 };
 
 BarWindow::BarWindow(QWidget* parent) :
@@ -140,9 +143,18 @@ BarWindow::BarWindow(QWidget* parent) :
 
     connect(&d->settings, &tSettings::settingChanged, this, [ = ](QString key, QVariant value) {
         if (key == "Appearance/translucent") {
+            d->translucencyEnabled = value.toBool();
             this->update();
         }
     });
+    connect(&d->settings, &tSettings::settingChanged, this, [ = ](QString key, QVariant value) {
+        if (key == "Appearance/opacity") {
+            d->translucencyOpacity = value.toInt();
+            this->update();
+        }
+    });
+    d->translucencyEnabled = d->settings.value("Appearance/translucent").toBool();
+    d->translucencyOpacity = d->settings.value("Appearance/opacity").toInt();
 
     KeyGrab* statusCenterGrab = new KeyGrab(QKeySequence(Qt::MetaModifier | Qt::Key_Tab));
     connect(statusCenterGrab, &KeyGrab::activated, this, [ = ] {
@@ -192,7 +204,7 @@ void BarWindow::leaveEvent(QEvent* event) {
 
 void BarWindow::paintEvent(QPaintEvent* event) {
     QColor bgCol = this->palette().color(QPalette::Window);
-    if (d->settings.value("Appearance/translucent").toBool()) bgCol.setAlpha(150);
+    if (d->translucencyEnabled) bgCol.setAlpha(d->translucencyOpacity);
 
     QPainter painter(this);
     painter.setPen(Qt::transparent);

--- a/desktop/defaults.conf
+++ b/desktop/defaults.conf
@@ -23,3 +23,4 @@ blacklist=
 
 [Appearance]
 translucent=true
+opacity=150

--- a/plugins/ThemePlugin/settings/themesettingspane.cpp
+++ b/plugins/ThemePlugin/settings/themesettingspane.cpp
@@ -28,6 +28,7 @@
 #include <QStandardPaths>
 #include <QStyleFactory>
 #include <QDir>
+#include <QTimer>
 
 struct ThemeSettingsPanePrivate {
     QSettings* kwinSettings;
@@ -84,6 +85,24 @@ ThemeSettingsPane::ThemeSettingsPane() :
         }
     });
     ui->transparencySwitch->setChecked(d->settings.value("Appearance/translucent").toBool());
+
+    connect(&d->settings, &tSettings::settingChanged, this, [ = ](QString key, QVariant value) {
+        if (key == "Appearance/opacity") {
+            ui->opacitySlider->setValue(value.toInt());
+            ui->opacitySliderLabel->setText(value.toString());
+            ui->opacitySliderLabel->setText(QString::number(
+                                                (value.toFloat())/255*100,
+                                                'g',3)+"%");
+        }
+    });
+    ui->opacitySlider->setValue(d->settings.value("Appearance/opacity").toInt());
+
+    // for some reason the slider label doesn't update early
+    QTimer::singleShot(100, this, [this](){
+        ui->opacitySliderLabel->setText(QString::number(
+                                            (d->settings.value("Appearance/opacity").toFloat())/255*100,
+                                            'g',3)+"%");
+    });
 }
 
 ThemeSettingsPane::~ThemeSettingsPane() {
@@ -247,4 +266,10 @@ void ThemeSettingsPane::on_setWindowBordersButton_clicked() {
 
 void ThemeSettingsPane::on_transparencySwitch_toggled(bool checked) {
     d->settings.setValue("Appearance/translucent", checked);
+}
+
+
+void ThemeSettingsPane::on_opacitySlider_valueChanged(int value)
+{
+     d->settings.setValue("Appearance/opacity", value);
 }

--- a/plugins/ThemePlugin/settings/themesettingspane.h
+++ b/plugins/ThemePlugin/settings/themesettingspane.h
@@ -62,6 +62,7 @@ class ThemeSettingsPane : public StatusCenterPane {
         void on_widgetThemeBox_currentIndexChanged(int index);
         void on_setWindowBordersButton_clicked();
         void on_transparencySwitch_toggled(bool checked);
+        void on_opacitySlider_valueChanged(int value);
 };
 
 #endif // THEMESETTINGSPANE_H

--- a/plugins/ThemePlugin/settings/themesettingspane.ui
+++ b/plugins/ThemePlugin/settings/themesettingspane.ui
@@ -48,9 +48,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-124</y>
-        <width>613</width>
-        <height>735</height>
+        <y>-195</y>
+        <width>715</width>
+        <height>783</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -531,6 +531,35 @@
        <item alignment="Qt::AlignHCenter">
         <widget class="QWidget" name="effectsWidget" native="true">
          <layout class="QGridLayout" name="gridLayout_5">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="text">
+             <string>Bar Opacity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSlider" name="opacitySlider">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximum">
+             <number>255</number>
+            </property>
+            <property name="value">
+             <number>150</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::NoTicks</enum>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_16">
             <property name="sizePolicy">
@@ -544,13 +573,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="tSwitch" name="transparencySwitch">
-            <property name="text">
-             <string notr="true">TransparencySwitch</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="label_15">
             <property name="font">
@@ -561,6 +583,38 @@
             </property>
             <property name="text">
              <string>EFFECTS</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="opacitySliderLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>100%</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="tSwitch" name="transparencySwitch">
+            <property name="text">
+             <string notr="true">TransparencySwitch</string>
             </property>
            </widget>
           </item>
@@ -596,15 +650,15 @@
    </slots>
   </customwidget>
   <customwidget>
+   <class>tSwitch</class>
+   <extends>QPushButton</extends>
+   <header location="global">tswitch.h</header>
+  </customwidget>
+  <customwidget>
    <class>AccentColourPicker</class>
    <extends>QWidget</extends>
    <header>settings/accentcolourpicker.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>tSwitch</class>
-   <extends>QPushButton</extends>
-   <header location="global">tswitch.h</header>
   </customwidget>
   <customwidget>
    <class>tConditionalWidget</class>

--- a/plugins/ThemePlugin/translations/aa_DJ.ts
+++ b/plugins/ThemePlugin/translations/aa_DJ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/aa_ER.ts
+++ b/plugins/ThemePlugin/translations/aa_ER.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/aa_ET.ts
+++ b/plugins/ThemePlugin/translations/aa_ET.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ab_GE.ts
+++ b/plugins/ThemePlugin/translations/ab_GE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/af_ZA.ts
+++ b/plugins/ThemePlugin/translations/af_ZA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/am_ET.ts
+++ b/plugins/ThemePlugin/translations/am_ET.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_AE.ts
+++ b/plugins/ThemePlugin/translations/ar_AE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_BH.ts
+++ b/plugins/ThemePlugin/translations/ar_BH.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_DJ.ts
+++ b/plugins/ThemePlugin/translations/ar_DJ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_DZ.ts
+++ b/plugins/ThemePlugin/translations/ar_DZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_EG.ts
+++ b/plugins/ThemePlugin/translations/ar_EG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_ER.ts
+++ b/plugins/ThemePlugin/translations/ar_ER.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_IQ.ts
+++ b/plugins/ThemePlugin/translations/ar_IQ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_JO.ts
+++ b/plugins/ThemePlugin/translations/ar_JO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_KM.ts
+++ b/plugins/ThemePlugin/translations/ar_KM.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_KW.ts
+++ b/plugins/ThemePlugin/translations/ar_KW.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_LB.ts
+++ b/plugins/ThemePlugin/translations/ar_LB.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_LY.ts
+++ b/plugins/ThemePlugin/translations/ar_LY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_MA.ts
+++ b/plugins/ThemePlugin/translations/ar_MA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_MR.ts
+++ b/plugins/ThemePlugin/translations/ar_MR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_OM.ts
+++ b/plugins/ThemePlugin/translations/ar_OM.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_PS.ts
+++ b/plugins/ThemePlugin/translations/ar_PS.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_QA.ts
+++ b/plugins/ThemePlugin/translations/ar_QA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_SA.ts
+++ b/plugins/ThemePlugin/translations/ar_SA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_SD.ts
+++ b/plugins/ThemePlugin/translations/ar_SD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_SO.ts
+++ b/plugins/ThemePlugin/translations/ar_SO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_SY.ts
+++ b/plugins/ThemePlugin/translations/ar_SY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_TD.ts
+++ b/plugins/ThemePlugin/translations/ar_TD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_TN.ts
+++ b/plugins/ThemePlugin/translations/ar_TN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_TZ.ts
+++ b/plugins/ThemePlugin/translations/ar_TZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ar_YE.ts
+++ b/plugins/ThemePlugin/translations/ar_YE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/as_IN.ts
+++ b/plugins/ThemePlugin/translations/as_IN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/au_AU.ts
+++ b/plugins/ThemePlugin/translations/au_AU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/az_AZ.ts
+++ b/plugins/ThemePlugin/translations/az_AZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/be_BY.ts
+++ b/plugins/ThemePlugin/translations/be_BY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/bg_BG.ts
+++ b/plugins/ThemePlugin/translations/bg_BG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/bi_VU.ts
+++ b/plugins/ThemePlugin/translations/bi_VU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/bn_BD.ts
+++ b/plugins/ThemePlugin/translations/bn_BD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/bs_BA.ts
+++ b/plugins/ThemePlugin/translations/bs_BA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ca_AD.ts
+++ b/plugins/ThemePlugin/translations/ca_AD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/cr_CA.ts
+++ b/plugins/ThemePlugin/translations/cr_CA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/cs_CZ.ts
+++ b/plugins/ThemePlugin/translations/cs_CZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/cy_GB.ts
+++ b/plugins/ThemePlugin/translations/cy_GB.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/da_DK.ts
+++ b/plugins/ThemePlugin/translations/da_DK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/de_AT.ts
+++ b/plugins/ThemePlugin/translations/de_AT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/de_CH.ts
+++ b/plugins/ThemePlugin/translations/de_CH.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/de_DE.ts
+++ b/plugins/ThemePlugin/translations/de_DE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/dv_MV.ts
+++ b/plugins/ThemePlugin/translations/dv_MV.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/dz_BT.ts
+++ b/plugins/ThemePlugin/translations/dz_BT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/el_GR.ts
+++ b/plugins/ThemePlugin/translations/el_GR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/en_AU.ts
+++ b/plugins/ThemePlugin/translations/en_AU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/en_CA.ts
+++ b/plugins/ThemePlugin/translations/en_CA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/en_GB.ts
+++ b/plugins/ThemePlugin/translations/en_GB.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/en_NZ.ts
+++ b/plugins/ThemePlugin/translations/en_NZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/en_US.ts
+++ b/plugins/ThemePlugin/translations/en_US.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/eo.ts
+++ b/plugins/ThemePlugin/translations/eo.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_AR.ts
+++ b/plugins/ThemePlugin/translations/es_AR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_BO.ts
+++ b/plugins/ThemePlugin/translations/es_BO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_CL.ts
+++ b/plugins/ThemePlugin/translations/es_CL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_CO.ts
+++ b/plugins/ThemePlugin/translations/es_CO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_DO.ts
+++ b/plugins/ThemePlugin/translations/es_DO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_EC.ts
+++ b/plugins/ThemePlugin/translations/es_EC.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_ES.ts
+++ b/plugins/ThemePlugin/translations/es_ES.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_GT.ts
+++ b/plugins/ThemePlugin/translations/es_GT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_HN.ts
+++ b/plugins/ThemePlugin/translations/es_HN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_MX.ts
+++ b/plugins/ThemePlugin/translations/es_MX.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_NI.ts
+++ b/plugins/ThemePlugin/translations/es_NI.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_PA.ts
+++ b/plugins/ThemePlugin/translations/es_PA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_PE.ts
+++ b/plugins/ThemePlugin/translations/es_PE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_PY.ts
+++ b/plugins/ThemePlugin/translations/es_PY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_SV.ts
+++ b/plugins/ThemePlugin/translations/es_SV.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_UY.ts
+++ b/plugins/ThemePlugin/translations/es_UY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/es_VE.ts
+++ b/plugins/ThemePlugin/translations/es_VE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/et_EE.ts
+++ b/plugins/ThemePlugin/translations/et_EE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/fa_IR.ts
+++ b/plugins/ThemePlugin/translations/fa_IR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/fi_FI.ts
+++ b/plugins/ThemePlugin/translations/fi_FI.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/fj_FJ.ts
+++ b/plugins/ThemePlugin/translations/fj_FJ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/fr_CA.ts
+++ b/plugins/ThemePlugin/translations/fr_CA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/fr_FR.ts
+++ b/plugins/ThemePlugin/translations/fr_FR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ga_IE.ts
+++ b/plugins/ThemePlugin/translations/ga_IE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/gn_PY.ts
+++ b/plugins/ThemePlugin/translations/gn_PY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ha_NE.ts
+++ b/plugins/ThemePlugin/translations/ha_NE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/he_IL.ts
+++ b/plugins/ThemePlugin/translations/he_IL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/hi_IN.ts
+++ b/plugins/ThemePlugin/translations/hi_IN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ho_PG.ts
+++ b/plugins/ThemePlugin/translations/ho_PG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/hr_HR.ts
+++ b/plugins/ThemePlugin/translations/hr_HR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ht_HT.ts
+++ b/plugins/ThemePlugin/translations/ht_HT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/hu_HU.ts
+++ b/plugins/ThemePlugin/translations/hu_HU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/hy_AM.ts
+++ b/plugins/ThemePlugin/translations/hy_AM.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/id_ID.ts
+++ b/plugins/ThemePlugin/translations/id_ID.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ig_NG.ts
+++ b/plugins/ThemePlugin/translations/ig_NG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/is_IS.ts
+++ b/plugins/ThemePlugin/translations/is_IS.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/it_IT.ts
+++ b/plugins/ThemePlugin/translations/it_IT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/iu_CA.ts
+++ b/plugins/ThemePlugin/translations/iu_CA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ja_JP.ts
+++ b/plugins/ThemePlugin/translations/ja_JP.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/jv_IN.ts
+++ b/plugins/ThemePlugin/translations/jv_IN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ka_GE.ts
+++ b/plugins/ThemePlugin/translations/ka_GE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ki_KE.ts
+++ b/plugins/ThemePlugin/translations/ki_KE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/kj_AO.ts
+++ b/plugins/ThemePlugin/translations/kj_AO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/kj_NA.ts
+++ b/plugins/ThemePlugin/translations/kj_NA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/kk_KZ.ts
+++ b/plugins/ThemePlugin/translations/kk_KZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/km_KH.ts
+++ b/plugins/ThemePlugin/translations/km_KH.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ko_KR.ts
+++ b/plugins/ThemePlugin/translations/ko_KR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ku_IR.ts
+++ b/plugins/ThemePlugin/translations/ku_IR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ky_KG.ts
+++ b/plugins/ThemePlugin/translations/ky_KG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/lb_LU.ts
+++ b/plugins/ThemePlugin/translations/lb_LU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/lg_UG.ts
+++ b/plugins/ThemePlugin/translations/lg_UG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ln_CD.ts
+++ b/plugins/ThemePlugin/translations/ln_CD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/lo_LA.ts
+++ b/plugins/ThemePlugin/translations/lo_LA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/lt_LT.ts
+++ b/plugins/ThemePlugin/translations/lt_LT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/lv_LV.ts
+++ b/plugins/ThemePlugin/translations/lv_LV.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/mg_MG.ts
+++ b/plugins/ThemePlugin/translations/mg_MG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/mi_NZ.ts
+++ b/plugins/ThemePlugin/translations/mi_NZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/mk_MK.ts
+++ b/plugins/ThemePlugin/translations/mk_MK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/mn_MN.ts
+++ b/plugins/ThemePlugin/translations/mn_MN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ms_MY.ts
+++ b/plugins/ThemePlugin/translations/ms_MY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ms_SG.ts
+++ b/plugins/ThemePlugin/translations/ms_SG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/mt_MT.ts
+++ b/plugins/ThemePlugin/translations/mt_MT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/my_MM.ts
+++ b/plugins/ThemePlugin/translations/my_MM.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/nb_NO.ts
+++ b/plugins/ThemePlugin/translations/nb_NO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ne_NP.ts
+++ b/plugins/ThemePlugin/translations/ne_NP.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/nl_BE.ts
+++ b/plugins/ThemePlugin/translations/nl_BE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/nl_NL.ts
+++ b/plugins/ThemePlugin/translations/nl_NL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/nn_NO.ts
+++ b/plugins/ThemePlugin/translations/nn_NO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pa_IN.ts
+++ b/plugins/ThemePlugin/translations/pa_IN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pa_PK.ts
+++ b/plugins/ThemePlugin/translations/pa_PK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pl_PL.ts
+++ b/plugins/ThemePlugin/translations/pl_PL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_AO.ts
+++ b/plugins/ThemePlugin/translations/pt_AO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_BR.ts
+++ b/plugins/ThemePlugin/translations/pt_BR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_CV.ts
+++ b/plugins/ThemePlugin/translations/pt_CV.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_GQ.ts
+++ b/plugins/ThemePlugin/translations/pt_GQ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_GW.ts
+++ b/plugins/ThemePlugin/translations/pt_GW.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_MZ.ts
+++ b/plugins/ThemePlugin/translations/pt_MZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_PT.ts
+++ b/plugins/ThemePlugin/translations/pt_PT.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_ST.ts
+++ b/plugins/ThemePlugin/translations/pt_ST.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/pt_TL.ts
+++ b/plugins/ThemePlugin/translations/pt_TL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/rn_BI.ts
+++ b/plugins/ThemePlugin/translations/rn_BI.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ro_MD.ts
+++ b/plugins/ThemePlugin/translations/ro_MD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ro_RO.ts
+++ b/plugins/ThemePlugin/translations/ro_RO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ru_BY.ts
+++ b/plugins/ThemePlugin/translations/ru_BY.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ru_KG.ts
+++ b/plugins/ThemePlugin/translations/ru_KG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ru_KZ.ts
+++ b/plugins/ThemePlugin/translations/ru_KZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ru_RU.ts
+++ b/plugins/ThemePlugin/translations/ru_RU.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/rw_RW.ts
+++ b/plugins/ThemePlugin/translations/rw_RW.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sg_CF.ts
+++ b/plugins/ThemePlugin/translations/sg_CF.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/si_LK.ts
+++ b/plugins/ThemePlugin/translations/si_LK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sk_SK.ts
+++ b/plugins/ThemePlugin/translations/sk_SK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sl_SI.ts
+++ b/plugins/ThemePlugin/translations/sl_SI.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sm_WS.ts
+++ b/plugins/ThemePlugin/translations/sm_WS.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/so_SO.ts
+++ b/plugins/ThemePlugin/translations/so_SO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sq_AL.ts
+++ b/plugins/ThemePlugin/translations/sq_AL.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sr_BA.ts
+++ b/plugins/ThemePlugin/translations/sr_BA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sr_RS.ts
+++ b/plugins/ThemePlugin/translations/sr_RS.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/st_LS.ts
+++ b/plugins/ThemePlugin/translations/st_LS.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/su_SD.ts
+++ b/plugins/ThemePlugin/translations/su_SD.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/sv_SE.ts
+++ b/plugins/ThemePlugin/translations/sv_SE.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/th_TH.ts
+++ b/plugins/ThemePlugin/translations/th_TH.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/tk_TM.ts
+++ b/plugins/ThemePlugin/translations/tk_TM.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/tl_PH.ts
+++ b/plugins/ThemePlugin/translations/tl_PH.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/to_TO.ts
+++ b/plugins/ThemePlugin/translations/to_TO.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/tr_TR.ts
+++ b/plugins/ThemePlugin/translations/tr_TR.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/uk_UA.ts
+++ b/plugins/ThemePlugin/translations/uk_UA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ur_PK.ts
+++ b/plugins/ThemePlugin/translations/ur_PK.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/uz_UZ.ts
+++ b/plugins/ThemePlugin/translations/uz_UZ.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/ve_ZA.ts
+++ b/plugins/ThemePlugin/translations/ve_ZA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/vi_VN.ts
+++ b/plugins/ThemePlugin/translations/vi_VN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation>Giao diện</translation>
     </message>
@@ -144,13 +144,23 @@
         <translation>Nhập ở đây!</translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/zh_CN.ts
+++ b/plugins/ThemePlugin/translations/zh_CN.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/zh_SG.ts
+++ b/plugins/ThemePlugin/translations/zh_SG.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/plugins/ThemePlugin/translations/zu_ZA.ts
+++ b/plugins/ThemePlugin/translations/zu_ZA.ts
@@ -44,7 +44,7 @@
     <name>ThemeSettingsPane</name>
     <message>
         <location filename="../settings/themesettingspane.ui" line="35"/>
-        <location filename="../settings/themesettingspane.cpp" line="198"/>
+        <location filename="../settings/themesettingspane.cpp" line="216"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -144,13 +144,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="543"/>
+        <location filename="../settings/themesettingspane.ui" line="537"/>
+        <source>Bar Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="572"/>
         <source>Transparency Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/themesettingspane.ui" line="563"/>
+        <location filename="../settings/themesettingspane.ui" line="585"/>
         <source>EFFECTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/themesettingspane.ui" line="604"/>
+        <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13794376/86033236-d321f200-ba62-11ea-93b3-9267b4e709ea.png)

Adds a slider bar below the transparency toggle. When the user changes the value in the slider, the opacity changes are applied instantly.